### PR TITLE
Toolify

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 
 In Development
 ==============
+* Allow for stripping/removing comments (needed by certain tools which
+  bundle python-archive)
+* Use relative import to allow module relocation.
 * Moved tests outside of the archive package directory.
 
 

--- a/archive/__init__.py
+++ b/archive/__init__.py
@@ -8,10 +8,12 @@ from archive.compat import IS_PY2, is_string
 
 class ArchiveException(Exception):
     """Base exception class for all archive errors."""
+    pass
 
 
 class UnrecognizedArchiveFormat(ArchiveException):
     """Error raised when passed file is not a recognized archive format."""
+    pass
 
 
 class UnsafeArchive(ArchiveException):
@@ -19,6 +21,7 @@ class UnsafeArchive(ArchiveException):
     Error raised when passed file contains paths that would be extracted
     outside of the target directory.
     """
+    pass
 
 
 def extract(path, to_path='', ext='', **kwargs):

--- a/archive/__init__.py
+++ b/archive/__init__.py
@@ -3,7 +3,7 @@ import sys
 import tarfile
 import zipfile
 
-from archive.compat import IS_PY2, is_string
+from .compat import IS_PY2, is_string
 
 
 class ArchiveException(Exception):


### PR DESCRIPTION
Hi this pull-request contains two changes. Both are motivated by the need "package/bundle" the module with a different stand-alone tool (see waf build-system).

Basically waf works by creating a self-extracting binary, with all the python code it needs bundled inside.

Two things happen:
1. All comments are stripped. This does not work with python-archive since it defines the exception classes with only a doc string. Leading to a syntax error when those doc strings are removed. Therefore I've added the `pass` statement.
2. The module gets relocated, there for the absolute import does not work, and we need to do a relative import.

Hope this could be accepted :)

Thanks for a nice module - all the best!